### PR TITLE
docs: remove http in endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ def run(plan, args = {}):
 
     service_a_metrics_job = { 
         "Name":"service_a", 
-        "Endpoint":"http://{0}:{1}".format(service_a.ip_address, service_a.ports["metrics"].number),
+        "Endpoint":"{0}:{1}".format(service_a.ip_address, service_a.ports["metrics"].number),
         "Labels": { 
             "service_type": "backend" 
         }


### PR DESCRIPTION
I noticed that when using an endpoint with the `http://` in it, it would cause this error:
```
There was an error executing Starlark code
An error occurred executing instruction (number 16) at github.com/kurtosis-tech/prometheus-package/main.star[74:42]:
  add_service(name="prometheus", config=ServiceConfig(image="prom/prometheus:latest", ports={"http": PortSpec(number=9090, transport_protocol="TCP", application_protocol="http")}, files={"/config": "prometheus-config"}, cmd=["--config.file=/config/prometheus-config.yml", "--storage.tsdb.path=/prometheus", "--storage.tsdb.retention.time=1d", "--storage.tsdb.retention.size=512MB", "--storage.tsdb.wal-compression", "--web.console.libraries=/etc/prometheus/console_libraries", "--web.console.templates=/etc/prometheus/consoles", "--web.enable-lifecycle"], max_cpu=1000, min_cpu=10, max_memory=2048, min_memory=128, node_selectors={}))
  Caused by: Unexpected error occurred starting service 'prometheus'
  Caused by: An error occurred waiting for all TCP and UDP ports to be open for service 'prometheus' with private IP '172.16.0.34'; this is usually due to a misconfiguration in the service itself, so here are the logs:
  == SERVICE 'prometheus' LOGS ===================================
  ts=2024-03-19T15:21:04.811Z caller=main.go:487 level=error msg="Error loading config (--config.file=/config/prometheus-config.yml)" file=/config/prometheus-config.yml err="parsing YAML file /config/prometheus-config.yml: \"http://172.16.0.41:9091\" is not a valid hostname"

  == FINISHED SERVICE 'prometheus' LOGS ===================================
  Caused by: An error occurred while waiting for all TCP and UDP ports to be open
  Caused by: Unsuccessful ports check for IP '172.16.0.34' and port spec '{privatePortSpec:0x4000bcd800}', even after '240' retries with '500' milliseconds in between retries. Timeout '2m0s' has been reached
  Caused by: An error occurred while calling network address '172.16.0.34:9090' with port protocol 'TCP' and using time out '200ms'
  Caused by: dial tcp 172.16.0.34:9090: i/o timeout

Error encountered running Starlark code.
```
Removing it resolved the issue and prometheus ran as expected.