### PR TITLE
fix: typo for labels in main.star

### DIFF
--- a/main.star
+++ b/main.star
@@ -116,7 +116,7 @@ def get_metrics_jobs(service_metrics_configs):
         
         labels = {}
         if "Labels" in metrics_config:
-            lables = metrics_config["Labels"]
+            labels = metrics_config["Labels"]
 
         metrics_path = "/metrics"
         if "MetricsPath" in metrics_config:


### PR DESCRIPTION
This will fix a typo for labels in the main.star.