### PR TITLE
feat: fallback scrape protocol

### DIFF
--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,4 +1,8 @@
-name: "github.com/kurtosis-tech/prometheus-package"
-description: |
-  # Prometheus
-  This is a Kurtosis package for launching a Prometheus server that scrapes metrics from services. See the `main.star#run` function for details on how to configure the server.
+# name: "github.com/kurtosis-tech/prometheus-package"
+# description: |
+#   # Prometheus
+#   This is a Kurtosis package for launching a Prometheus server that scrapes metrics from services. See the `main.star#run` function for details on how to configure the server.
+
+name: github.com/minhd-vu/prometheus-package
+replace:
+  github.com/kurtosis-tech/prometheus-package: github.com/minhd-vu/prometheus-package

--- a/kurtosis.yml
+++ b/kurtosis.yml
@@ -1,8 +1,4 @@
-# name: "github.com/kurtosis-tech/prometheus-package"
-# description: |
-#   # Prometheus
-#   This is a Kurtosis package for launching a Prometheus server that scrapes metrics from services. See the `main.star#run` function for details on how to configure the server.
-
-name: github.com/minhd-vu/prometheus-package
-replace:
-  github.com/kurtosis-tech/prometheus-package: github.com/minhd-vu/prometheus-package
+name: "github.com/kurtosis-tech/prometheus-package"
+description: |
+  # Prometheus
+  This is a Kurtosis package for launching a Prometheus server that scrapes metrics from services. See the `main.star#run` function for details on how to configure the server.

--- a/main.star
+++ b/main.star
@@ -41,7 +41,11 @@ def run(
 
                     # how frequently to scrape targets from this job
                     # optional
-                    ScrapeInterval: "15s"
+                    ScrapeInterval: "15s",
+
+                    # fallback protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type
+                    # optional
+                    FallbackScrapeProtocol: "http"
                 },
                 {
                     ...
@@ -141,6 +145,10 @@ def get_metrics_jobs(service_metrics_configs):
         if "ScrapeInterval" in metrics_config:
             scrape_interval = metrics_config["ScrapeInterval"]
 
+        fallback_scrape_interval = "http"
+        if "FallbackScrapeProtocol" in metrics_config:
+            fallback_scrape_interval = metrics_config["FallbackScrapeProtocol"]
+
         metrics_jobs.append(
             {
                 "Name": metrics_config["Name"],
@@ -148,6 +156,7 @@ def get_metrics_jobs(service_metrics_configs):
                 "Labels": labels,
                 "MetricsPath": metrics_path,
                 "ScrapeInterval": scrape_interval,
+                "FallbackScrapeProtocol": fallback_scrape_interval,
             }
         )
 

--- a/main.star
+++ b/main.star
@@ -45,7 +45,7 @@ def run(
 
                     # fallback protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type
                     # optional
-                    FallbackScrapeProtocol: "http"
+                    FallbackScrapeProtocol: "PrometheusText0.0.4"
                 },
                 {
                     ...
@@ -145,7 +145,7 @@ def get_metrics_jobs(service_metrics_configs):
         if "ScrapeInterval" in metrics_config:
             scrape_interval = metrics_config["ScrapeInterval"]
 
-        fallback_scrape_interval = "http"
+        fallback_scrape_interval = "PrometheusText0.0.4"
         if "FallbackScrapeProtocol" in metrics_config:
             fallback_scrape_interval = metrics_config["FallbackScrapeProtocol"]
 

--- a/static-files/prometheus.yml.tmpl
+++ b/static-files/prometheus.yml.tmpl
@@ -12,4 +12,5 @@ scrape_configs:
         labels:{{ range $labelName, $labelValue := $job.Labels }}
           {{ $labelName }}: "{{ $labelValue }}"
         {{- end }}
+    fallback_scrape_protocol: "{{ $job.FallbackScrapeProtocol }}"
   {{- end }}


### PR DESCRIPTION
Prometheus v3 introduced the `fallback_scrape_protocol` option in the scrape config. I believe before it would use `PrometheusText0.0.4`. Read more about the breaking change here: https://prometheus.io/docs/prometheus/3.0/migration/#scrape-protocols